### PR TITLE
First refactoring of 'pagy/extra/elasticsearch_rails'

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -7,7 +7,7 @@ class NotesController < ApplicationController
   # GET /notes.json
   def index
     if params[:q].present?
-      @pagy, @notes = pagy_elasticsearch_rails(Note.search(params[:q]).records)
+      @pagy, @notes = pagy_elasticsearch_rails(Note.pagy_search(params[:q]).records)
     else
       @pagy, @notes = pagy(Note.order(created_at: :desc))
     end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -3,4 +3,5 @@ require 'elasticsearch/model'
 class Note < ApplicationRecord
   include Elasticsearch::Model
   include Elasticsearch::Model::Callbacks
+  extend Pagy::Elasticsearch::Model
 end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -19,7 +19,8 @@
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects efficiently, avoiding expensive object-wrapping and without overriding.
 # See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
-require 'pagy/extras/elasticsearch_rails'
+# require 'pagy/extras/elasticsearch_rails'
+require Rails.root.join('lib', 'elasticsearch_rails')
 
 # Searchkick extra: Paginate `Searchkick::Results` objects efficiently, avoiding expensive object-wrapping and without overriding.
 # See https://ddnexus.github.io/pagy/extras/searchkick

--- a/lib/elasticsearch_rails.rb
+++ b/lib/elasticsearch_rails.rb
@@ -1,0 +1,39 @@
+# See the Pagy documentation: https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# encoding: utf-8
+# frozen_string_literal: true
+
+class Pagy
+
+  module Elasticsearch
+    module Model
+      def pagy_search(query_or_payload, options={})
+        [self, query_or_payload, options].tap do |args|
+          args.define_singleton_method(:method_missing){|*a| args += a}
+        end
+      end
+    end
+  end
+
+  # Add specialized backend methods to paginate ElasticsearchRails::Results
+  module Backend ; private
+    # Return Pagy object and items
+    def pagy_elasticsearch_rails(search_args, vars={})
+      vars = pagy_elasticsearch_rails_get_vars(vars)
+      model, query_or_payload, options, *called = search_args
+      options[:size] = vars[:items]
+      options[:from] = options[:size] * (vars[:page].to_i - 1)
+      response       = model.search(query_or_payload, options)
+      vars[:count]   = response.raw_response['hits']['total']
+
+      return Pagy.new(vars), called.empty? ? response : response.send(*called)
+    end
+
+    # Sub-method called only by #pagy_elasticsearch_rails: here for easy customization of variables by overriding
+    def pagy_elasticsearch_rails_get_vars(vars)
+      vars[:page]  ||= params[ vars[:page_param] || VARS[:page_param] ] || 1
+      vars[:items] ||= VARS[:items]
+      vars
+    end
+
+  end
+end


### PR DESCRIPTION
This refactoring fixes a few problems and makes it more flexible. You could also remove the `.records` and it will return the paginated response, and you can call also other methods if you need to.

I will have to write tests, add support for the `items` extra and write a new documentation. Since it contains breaking changes, it will go with the pagy v2.0, which is in development and will be released soon.

FYI: @Kani999